### PR TITLE
Add release trigger for MAUI unit tests workflow

### DIFF
--- a/.github/workflows/maui-tests.yml
+++ b/.github/workflows/maui-tests.yml
@@ -1,6 +1,8 @@
 name: MAUI Unit Tests
 
 on:
+  release:
+    types: [created]
   push:
     branches:
       - main


### PR DESCRIPTION
workflow has been edited so  that when a release is created the workflow does one more test to confirm functionality.